### PR TITLE
Account select

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -1,7 +1,6 @@
 ---
 cluster:
   - "owens"
-  - "owens-slurm"
 form:
   - bc_account
   - bc_num_hours

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -1,8 +1,13 @@
+<%-
+  groups = OodSupport::User.new.groups.sort_by(&:id).tap { |groups|
+    groups.unshift(groups.delete(OodSupport::Process.group))
+  }.map(&:name).grep(/^P./)
+-%>
 ---
 cluster:
   - "owens"
 form:
-  - bc_account
+  - account
   - bc_num_hours
   - bc_num_slots
   - node_type
@@ -11,9 +16,13 @@ form:
   - include_tutorials
   - bc_email_on_started
 attributes:
-  bc_account:
+  account:
     label: "Project"
-    help: "You can leave this blank if **not** in multiple projects."
+    widget: select
+    options:
+      <%- groups.each do |group| %>
+      - "<%= group %>"
+      <%- end %>
   num_workers:
     widget: "number_field"
     value: "1"

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -20,6 +20,7 @@ batch_connect:
   template: "basic"
   conn_params: [ "tutorials_root" ]
 script:
+  accounting_id: "<%= account %>"
   native:
   <%- slurm_args.each do |arg| %>
     - "<%= arg %>"

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -1,5 +1,4 @@
 <%-
-  torque_cluster = OodAppkit.clusters[cluster].job_config[:adapter] == 'torque'
 
   base_slurm_args = if bc_num_slots.blank?
                       ["--nodes", "1", "--exclusive"]
@@ -15,13 +14,6 @@
                   base_slurm_args
                 end
 
-  torque_args =  case node_type
-                when "hugemem"
-                  ":ppn=48:hugemem"
-                else
-                  ":ppn=28"
-                end
-
 -%>
 ---
 batch_connect:
@@ -29,11 +21,6 @@ batch_connect:
   conn_params: [ "tutorials_root" ]
 script:
   native:
-  <%- if torque_cluster %>
-    resources:
-      nodes: "<%= bc_num_slots.blank? ? "1" : bc_num_slots.to_i %><%= torque_args %>"
-  <% else %>
   <%- slurm_args.each do |arg| %>
     - "<%= arg %>"
-  <%- end %>
   <%- end %>


### PR DESCRIPTION
This changes the account field to be a select widget for only valid project codes to help users only use valid project codes while forcing them to supply one.

It also removes all the now vestigial torque items.