### PR TITLE
update jupyster module to .17

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -92,7 +92,7 @@ attributes:
     label: "JupyterLab Version"
     options:
       - [
-        "3.0", "app_jupyter/3.0.7",
+        "3.0", "app_jupyter/3.0.17",
         data-option-for-cluster-pitzer: false
         ]
       - [


### PR DESCRIPTION
update jupyster module to `3.0.17` because `3.0.7` doesn't exist.