### PR TITLE
Enable v3 in pitzer

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -85,7 +85,6 @@ attributes:
         ]
       - [
         "3.0.1", "3.0.1",
-        data-option-for-cluster-pitzer: false
         ]
   version:
     widget: "select"

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -93,7 +93,6 @@ attributes:
     options:
       - [
         "3.0", "app_jupyter/3.0.17",
-        data-option-for-cluster-pitzer: false
         ]
       - [
         "2.2", "app_jupyter/2.2.10",


### PR DESCRIPTION
This enables both spark version 3 and jupyter version 3 in pitzer which for whatever reason didn't have them.