### PR TITLE
Max mem workers

### DIFF
--- a/template/before.sh.erb
+++ b/template/before.sh.erb
@@ -33,7 +33,7 @@
 
   def exec_memory
     calculated = avail_mem/context.num_workers.to_i
-    [20, calculated].min
+    [60, calculated].min
   end
 
   spark_config = {

--- a/template/before.sh.erb
+++ b/template/before.sh.erb
@@ -31,6 +31,11 @@
     end
   end
 
+  def exec_memory
+    calculated = avail_mem/context.num_workers.to_i
+    [20, calculated].min
+  end
+
   spark_config = {
     "spark.ui.reverseProxy" => "true",
     #"spark.ui.reverseProxyUrl" => "https://ondemand.osc.edu/node/${SPARK_MASTER_HOST}/${SPARK_MASTER_WEBUI_PORT}",
@@ -46,7 +51,7 @@
 
   def pyspark_submit_args
     args = []
-    args.concat(["--executor-memory  #{avail_mem/context.num_workers.to_i}G"]) unless extra_spark_config.has_key?('spark.executor.memory')
+    args.concat(["--executor-memory  #{exec_memory}G"]) unless extra_spark_config.has_key?('spark.executor.memory')
     args.concat(['--conf spark.driver.maxResultSize=0']) unless extra_spark_config.has_key?("spark.driver.maxResultSize")
 
     if extra_spark_config.has_key?('spark.driver.memory')


### PR DESCRIPTION
Put a cap on the memory of workers because a default value of 1 worker on a node gives 120 GB (on owens) which doesn't work for the tutorials (they hang).