### PR TITLE
Support a custom kernel to utilize the master and worker at startup

### DIFF
--- a/template/before.sh.erb
+++ b/template/before.sh.erb
@@ -250,6 +250,16 @@ chmod 700 "${SPARK_WORKER_SCRIPT}"
 echo "Launching workers..."
 srun --export ALL --ntasks <%= total_tasks %> "${SPARK_WORKER_SCRIPT}" &
 
+# Required to support a custom kernel
+export PYSPARK_SUBMIT_ARGS=" \
+    --master spark://${SPARK_MASTER_HOST}:${SPARK_MASTER_PORT} \
+    --properties-file \"${SPARK_CONFIG_FILE}\" \
+    <%- pyspark_submit_args.each do |arg| -%>
+    <%= arg %> \
+    <%- end -%>
+    pyspark-shell \
+"
+
 #
 # Launch Jupyter with PySpark
 #
@@ -273,14 +283,6 @@ sed 's/^ \{2\}//' > "${PYTHON_WRAPPER_FILE}" << EOL
   export PYTHONPATH="\${SPARK_HOME}/python:\$PYTHONPATH"
   export PYTHONPATH="\${SPARK_PY4J_PATH}:\$PYTHONPATH"
   export PYTHONSTARTUP="\${SPARK_HOME}/python/pyspark/shell.py"
-  export PYSPARK_SUBMIT_ARGS=" \\
-    --master spark://${SPARK_MASTER_HOST}:${SPARK_MASTER_PORT} \\
-    --properties-file \"${SPARK_CONFIG_FILE}\" \\
-    <%- pyspark_submit_args.each do |arg| -%>
-    <%= arg %> \\
-    <%- end -%>
-    pyspark-shell \\
-  "
 
   # Launch the original command
   set -x

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -47,6 +47,7 @@ module load project/ondemand xalt/latest <%= context.version %>
 <%- else -%>
 module load ondemand/project xalt/latest <%= context.version %>
 <%- end -%>
+module load spark/<%= context.spark_version %>
 module list
 
 echo "TTT - $(date)"


### PR DESCRIPTION
### Change notes
I made two changes:
1. Set `PYSPARK_SUBMIT_ARGS` globally – This is required for the Spark driver in a custom kernel to communicate with the existing master and workers.
2. Load the Spark module globally – This is necessary because the master and worker processes are started using Java classes from the Spark module.

### Summary
These changes enable a custom kernel to utilize the master and workers originally set up for the PySpark kernel. I tested this by running a PySpark application in parallel in both PySpark and a custom kernel, and the results were identical.

However, since the master and workers are initialized using Python 3.12, a custom kernel must also be created with the same Python version. Otherwise, the following error occurs:
```
pyspark.errors.exceptions.base.PySparkRuntimeError: [PYTHON_VERSION_MISMATCH] Python in worker has different version (3, 12) than that in driver 3.10, PySpark cannot run with different minor versions.
Please check environment variables PYSPARK_PYTHON and PYSPARK_DRIVER_PYTHON are correctly set.
```

