### PR TITLE
rm python and xalt here

### DIFF
--- a/template/before.sh.erb
+++ b/template/before.sh.erb
@@ -138,12 +138,7 @@ module purge
 # Load the runtime environment
 runtime_env() {
   module purge
-  module load xalt/latest
-  <%- unless ['cardinal', 'ascend-nextgen'].include?(context.cluster) -%>
-  module load python/3.6-conda5.2 spark/<%= context.spark_version %>
-  <%- else -%>
-  module load python/3.12 spark/<%= context.spark_version %>
-  <%- end -%>
+  module load spark/<%= context.spark_version %>
 
   # Disable randomized hash for string in Python 3.3+
   export PYTHONHASHSEED=0


### PR DESCRIPTION
rm python and xalt here. python is not required here to boot spark. Also xalt is going away and not on all clusters.