### PR TITLE
Support multiple python versions for RHEL 9 system

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -7,6 +7,7 @@ form:
   - auto_accounts
   - jupyterlab_switch
   - spark_version
+  - python_version
   - bc_num_hours
   - bc_num_slots
   - node_type
@@ -89,6 +90,24 @@ attributes:
         "2.3.0", "2.3.0",
         data-option-for-cluster-pitzer: false,
         data-option-for-cluster-ascend: false,
+        ]
+  python_version:
+    widget: "select"
+    label: "Python Version"
+    help: |
+      Specify the Python version to match the one used in your Conda environment. This ensures compatibility when setting up the Spark cluster and helps prevent issues related to Python version mismatches. Choose Python 3.12 if you want to use the default PySpark kernel.
+    options:
+      - [
+          "3.12", "python/3.12",
+           data-option-for-cluster-pitzer: false,
+        ]
+      - [
+          "3.10", "miniconda3/24.1.2-py310",
+           data-option-for-cluster-pitzer: false,
+        ]
+      - [
+          "3.9", "",
+           data-option-for-cluster-pitzer: false,
         ]
   version:
     widget: "select"

--- a/template/before.sh.erb
+++ b/template/before.sh.erb
@@ -141,7 +141,7 @@ runtime_env() {
   <%- unless ['cardinal', 'ascend'].include?(context.cluster) -%>
   module load python/3.6-conda5.2 spark/<%= context.spark_version %>
   <%- else -%>
-  module load python/3.12 spark/<%= context.spark_version %>
+  module load <%= context.python_version %> spark/<%= context.spark_version %>
   <%- end -%>
 
   # Disable randomized hash for string in Python 3.3+


### PR DESCRIPTION
@johrstrom 

I have modified the `form.yml` and `template/before.sh` to support Python versions 3.9, 3.10, and 3.12. However, there are a couple of changes I would still like to make, but I am not sure how to approach them:
* Hide the Python version selection on Pitzer RHEL 7.
* Set Python 3.12 as the default option, so generic users are not caught off guard.

Could you help me with these changes? Thanks!